### PR TITLE
Elasticsearch config

### DIFF
--- a/app/common/config.py
+++ b/app/common/config.py
@@ -6,6 +6,8 @@ class Settings(BaseSettings):
     max_query_size: int = 1000
     # Wait in case elastic is starting in parallel
     retry_connection: int = 120
+    ilm_policy_max_docs: int = 10000000
+    ilm_policy_max_primary_shard_size: str = "50gb"
 
 
 settings = Settings()

--- a/app/common/db/base_class.py
+++ b/app/common/db/base_class.py
@@ -16,8 +16,6 @@ logger = logging.getLogger("sds_common")
 class TooManyHitsException(Exception):
     """Raised when the number of hits exceeds the limit"""
 
-    pass
-
 
 class Base(BaseModel):
     id: Optional[str]

--- a/app/common/db/utils.py
+++ b/app/common/db/utils.py
@@ -35,3 +35,26 @@ def dict_to_filters(dict: Dict) -> List[Dict]:
     for k, v in dict.items():
         clauses.extend(item_to_filters(k, v))
     return clauses
+
+
+class UpdateRequiredException(Exception):
+    """
+    This exceptions signals the need to update elasticsearch configuration,
+    be it because the configuration is missing or needs to be updated.
+    """
+
+
+def check_dict_for_updated_entries(current_dict, new_dict):
+    """
+    Checks if all keys in the new configuration are present in the current configuration,
+    and if their values match.
+    The current configuration may have extra keys that are automatically added by
+    elasticsearch and are therefore ignored.
+    """
+    for key in new_dict.keys():
+        if key not in current_dict:
+            raise UpdateRequiredException
+        if type(current_dict[key]) is dict:
+            check_dict_for_updated_entries(current_dict[key], new_dict[key])
+        elif current_dict[key] != new_dict[key]:
+            raise UpdateRequiredException

--- a/app/common/models/dataset.py
+++ b/app/common/models/dataset.py
@@ -1,5 +1,21 @@
+import logging
+import time
+
+from common.config import settings
+from common.db.utils import UpdateRequiredException, check_dict_for_updated_entries
 from common.db.base_class import Base
+from common.db.connection import get_connection
 from common.db.fields import Date, Integer, Keyword
+from elasticsearch import AsyncElasticsearch, NotFoundError
+from elasticsearch.client import IlmClient
+
+logger = logging.getLogger("sds_common")
+
+DATASET_POLICY_NAME = "dataset_policy"
+DATASET_MAPPING_TEMPLATE = "dataset_mapping"
+DATASET_INDEX_SETTINGS_TEMPLATE = "dataset_index_settings"
+COMPONENT_TEMPLATE_STR = "component_templates"
+DATASET_INDEX_TEMPLATE = "dataset_template"
 
 
 class Dataset(Base):
@@ -7,7 +23,172 @@ class Dataset(Base):
     trigger_date: Date
     trigger_pulse_id: Integer
     path: Keyword
-    created: Date
 
     class Index:
         name = "dataset"
+
+    def document(self):
+        """
+        Overriding this method to add the @timestamp field that cannot be added as a class member
+        """
+        document = super().document()
+        document["@timestamp"] = Date.to_es(time.time())
+        return document
+
+    @classmethod
+    def mappings(cls):
+        """
+        Overriding this method to add the @timestamp field that cannot be added as a class member
+        """
+        mappings = super().mappings()
+        mappings["properties"]["@timestamp"] = {"type": Date.es_type}
+        return mappings
+
+    @classmethod
+    async def init(cls):
+        """
+        Datasets are stored in a data stream that automatically handles creation of new indices.
+        This method initializes or updates (if needed) the Index Lifecicle Management policies
+        and it creates the component templates and the index template that generetes the data stream.
+        """
+        async with get_connection() as es:
+            # Set or update the ILM policy
+            await cls.init_ilm_policy(es)
+
+            # Create or update component templates
+            await cls.init_dataset_mapping_template(es)
+            await cls.init_dataset_index_settings(es)
+
+            # Create or update index template
+            await cls.init_index_template(es)
+
+    @classmethod
+    async def init_ilm_policy(cls, es: AsyncElasticsearch):
+        ilm_policy = {
+            "_meta": {
+                "description": "ILM policy for dataset data stream",
+            },
+            "phases": {
+                "hot": {
+                    "actions": {
+                        "rollover": {
+                            "max_docs": str(settings.ilm_policy_max_docs),
+                            "max_primary_shard_size": settings.ilm_policy_max_primary_shard_size,
+                        }
+                    },
+                },
+                "warm": {
+                    "actions": {
+                        "shrink": {"number_of_shards": 1},
+                        "forcemerge": {"max_num_segments": 1},
+                    },
+                },
+            },
+        }
+
+        client = IlmClient(es)
+
+        try:
+            current_policy = await client.get_lifecycle(name=DATASET_POLICY_NAME)
+            check_dict_for_updated_entries(
+                current_policy[DATASET_POLICY_NAME]["policy"], ilm_policy
+            )
+        except (NotFoundError, UpdateRequiredException):
+            logger.info("ES dataset_policy ILM policy created or updated")
+            await client.put_lifecycle(name=DATASET_POLICY_NAME, policy=ilm_policy)
+
+    @classmethod
+    async def init_dataset_mapping_template(cls, es: AsyncElasticsearch):
+        try:
+            dataset_mapping_template = await es.cluster.get_component_template(
+                name=DATASET_MAPPING_TEMPLATE
+            )
+            dataset_mapping_template = dataset_mapping_template.get(
+                COMPONENT_TEMPLATE_STR, None
+            )
+            if dataset_mapping_template is None:
+                raise UpdateRequiredException
+            for template in dataset_mapping_template:
+                if template["name"] == DATASET_MAPPING_TEMPLATE:
+                    try:
+                        check_dict_for_updated_entries(
+                            template["component_template"]["template"]["mappings"],
+                            cls.mappings(),
+                        )
+                    except NameError:
+                        raise UpdateRequiredException
+                else:
+                    raise UpdateRequiredException
+        except (NotFoundError, UpdateRequiredException):
+            logger.info("ES dataset_mapping template created or updated")
+            await es.cluster.put_component_template(
+                name=DATASET_MAPPING_TEMPLATE, template={"mappings": cls.mappings()}
+            )
+
+    @classmethod
+    async def init_dataset_index_settings(cls, es: AsyncElasticsearch):
+        try:
+            dataset_index_settings = await es.cluster.get_component_template(
+                name=DATASET_INDEX_SETTINGS_TEMPLATE
+            )
+            dataset_index_settings = dataset_index_settings.get(
+                COMPONENT_TEMPLATE_STR, None
+            )
+            if dataset_index_settings is None:
+                raise UpdateRequiredException
+            for template in dataset_index_settings:
+                if template["name"] == DATASET_INDEX_SETTINGS_TEMPLATE:
+                    try:
+                        if (
+                            template["component_template"]["template"]["settings"][
+                                "index"
+                            ]["lifecycle"]["name"]
+                            != DATASET_POLICY_NAME
+                        ):
+                            raise UpdateRequiredException
+                    except NameError:
+                        raise UpdateRequiredException
+                else:
+                    raise UpdateRequiredException
+        except (NotFoundError, UpdateRequiredException):
+            logger.info("ES dataset_index_settings template created or updated")
+            await es.cluster.put_component_template(
+                name=DATASET_INDEX_SETTINGS_TEMPLATE,
+                template={"settings": {"index.lifecycle.name": DATASET_POLICY_NAME}},
+            )
+
+    @classmethod
+    async def init_index_template(cls, es: AsyncElasticsearch):
+        dataset_index_template = {
+            "composed_of": [DATASET_MAPPING_TEMPLATE, DATASET_INDEX_SETTINGS_TEMPLATE],
+            "data_stream": {},
+            "priority": 500,
+            "index_patterns": ["dataset*"],
+            "_meta": {"description": "Template for the dataset schema"},
+        }
+
+        try:
+            existing_dataset_index_template = await es.indices.get_index_template(
+                name=DATASET_INDEX_TEMPLATE
+            )
+            existing_dataset_index_template = existing_dataset_index_template.get(
+                "index_templates", None
+            )
+            if existing_dataset_index_template is None:
+                raise UpdateRequiredException
+            for template in existing_dataset_index_template:
+                if template["name"] == DATASET_INDEX_TEMPLATE:
+                    if template["index_template"] is None:
+                        raise UpdateRequiredException
+                    check_dict_for_updated_entries(
+                        template["index_template"],
+                        dataset_index_template,
+                    )
+                else:
+                    raise UpdateRequiredException
+        except (NotFoundError, UpdateRequiredException):
+            logger.info("ES dataset_template template created or updated")
+            await es.indices.put_index_template(
+                name=DATASET_INDEX_TEMPLATE,
+                **dataset_index_template,
+            )

--- a/app/common/schemas/dataset.py
+++ b/app/common/schemas/dataset.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from datetime import datetime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from pathlib import PurePosixPath as UnvalidatedPurePosixPath
 
 
@@ -36,12 +36,10 @@ class DatasetBase(BaseModel):
 
 class DatasetCreate(DatasetBase):
     expire_in: Optional[int]
-    created: Optional[datetime] = Field(default_factory=datetime.utcnow)
 
 
 class DatasetInDBBase(DatasetBase):
     id: str
-    created: datetime
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
The dataset index is expected to continuously grow exceeding the Lucene limit for number of documents.
For this reason, and to optimize search on the index, dataset is now configured as a data stream with automatic rollup of indices.
A ILM policy is also added to optimize the indices.